### PR TITLE
Speedup SparseChunk iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### CHANGED
+
+-   Improved the performance of SpareChunk iterators.
+
 ## [0.1.2] - 2024-01-20
 
 ### ADDED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### CHANGED
 
--   Improved the performance of SpareChunk iterators.
+-   Improved the performance of SparseChunk iterators.
 
 ## [0.1.2] - 2024-01-20
 

--- a/src/sparse_chunk/mod.rs
+++ b/src/sparse_chunk/mod.rs
@@ -246,7 +246,7 @@ where
     /// Make an iterator of references to the values contained in the array.
     pub fn iter(&self) -> Iter<'_, A, N> {
         Iter {
-            indices: self.indices(),
+            bitmap: self.map,
             chunk: self,
         }
     }


### PR DESCRIPTION
The `bitmap` crate iterators are really slow and could be improved, but the crate looks unmaintained.

This PR changes SparseChunk non-mut iterators to use the same strategy as the mutable one, which is to call first_index + reset the bit. This is significantly faster and boils down to a few instructions.

I'll follow up with actual numbers in the `imbl` PR.