### PR TITLE
Add as_mut_slice_ptr

### DIFF
--- a/src/sized_chunk/mod.rs
+++ b/src/sized_chunk/mod.rs
@@ -700,6 +700,17 @@ impl<A, const N: usize> Chunk<A, N> {
             )
         }
     }
+
+    /// Get a pointer to the contents of the chunk as a slice
+    ///
+    /// # Safety
+    ///
+    /// The provided chunk pointer must be dereferencable
+    pub unsafe fn as_mut_slice_ptr(this: *mut Self) -> *mut [A] {
+        // Manual `len` to prevent creating a reference
+        let len = (*this).right - (*this).left;
+        ptr::slice_from_raw_parts_mut(ptr::addr_of_mut!((*this).data).cast(), len)
+    }
 }
 
 impl<A, const N: usize> Default for Chunk<A, N> {


### PR DESCRIPTION
 For getting slice pointers out of Chunks without… invalidating references. Needed by https://github.com/jneem/imbl/pull/83