### PR TITLE
Fix lints

### DIFF
--- a/src/inline_array/iter.rs
+++ b/src/inline_array/iter.rs
@@ -40,7 +40,7 @@ pub struct Drain<'a, A, T> {
     pub(crate) array: &'a mut InlineArray<A, T>,
 }
 
-impl<'a, A, T> Iterator for Drain<'a, A, T> {
+impl<A, T> Iterator for Drain<'_, A, T> {
     type Item = A;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -52,12 +52,12 @@ impl<'a, A, T> Iterator for Drain<'a, A, T> {
     }
 }
 
-impl<'a, A, T> DoubleEndedIterator for Drain<'a, A, T> {
+impl<A, T> DoubleEndedIterator for Drain<'_, A, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.array.pop()
     }
 }
 
-impl<'a, A, T> ExactSizeIterator for Drain<'a, A, T> {}
+impl<A, T> ExactSizeIterator for Drain<'_, A, T> {}
 
-impl<'a, A, T> FusedIterator for Drain<'a, A, T> {}
+impl<A, T> FusedIterator for Drain<'_, A, T> {}

--- a/src/inline_array/mod.rs
+++ b/src/inline_array/mod.rs
@@ -149,12 +149,13 @@ impl<A, T> InlineArray<A, T> {
     #[inline]
     #[must_use]
     unsafe fn len_const(&self) -> *const usize {
-        let ptr = self
-            .data
-            .as_ptr()
-            .cast::<A>()
-            .add(Self::HEADER_SKIP)
-            .cast::<usize>();
+        let ptr = unsafe {
+            self.data
+                .as_ptr()
+                .cast::<A>()
+                .add(Self::HEADER_SKIP)
+                .cast::<usize>()
+        };
         debug_assert!(ptr as usize % mem::align_of::<usize>() == 0);
         ptr
     }
@@ -162,12 +163,13 @@ impl<A, T> InlineArray<A, T> {
     #[inline]
     #[must_use]
     pub(crate) unsafe fn len_mut(&mut self) -> *mut usize {
-        let ptr = self
-            .data
-            .as_mut_ptr()
-            .cast::<A>()
-            .add(Self::HEADER_SKIP)
-            .cast::<usize>();
+        let ptr = unsafe {
+            self.data
+                .as_mut_ptr()
+                .cast::<A>()
+                .add(Self::HEADER_SKIP)
+                .cast::<usize>()
+        };
         debug_assert!(ptr as usize % mem::align_of::<usize>() == 0);
         ptr
     }
@@ -178,12 +180,13 @@ impl<A, T> InlineArray<A, T> {
         if Self::CAPACITY == 0 {
             return NonNull::<A>::dangling().as_ptr();
         }
-        let ptr = self
-            .data
-            .as_ptr()
-            .cast::<usize>()
-            .add(Self::ELEMENT_SKIP)
-            .cast::<A>();
+        let ptr = unsafe {
+            self.data
+                .as_ptr()
+                .cast::<usize>()
+                .add(Self::ELEMENT_SKIP)
+                .cast::<A>()
+        };
         debug_assert!(ptr as usize % mem::align_of::<A>() == 0);
         ptr
     }
@@ -194,12 +197,13 @@ impl<A, T> InlineArray<A, T> {
         if Self::CAPACITY == 0 {
             return NonNull::<A>::dangling().as_ptr();
         }
-        let ptr = self
-            .data
-            .as_mut_ptr()
-            .cast::<usize>()
-            .add(Self::ELEMENT_SKIP)
-            .cast::<A>();
+        let ptr = unsafe {
+            self.data
+                .as_mut_ptr()
+                .cast::<usize>()
+                .add(Self::ELEMENT_SKIP)
+                .cast::<A>()
+        };
         debug_assert!(ptr as usize % mem::align_of::<A>() == 0);
         ptr
     }
@@ -208,24 +212,24 @@ impl<A, T> InlineArray<A, T> {
     #[must_use]
     unsafe fn ptr_at(&self, index: usize) -> *const A {
         debug_assert!(index < Self::CAPACITY);
-        self.data().add(index)
+        unsafe { self.data().add(index) }
     }
 
     #[inline]
     #[must_use]
     unsafe fn ptr_at_mut(&mut self, index: usize) -> *mut A {
         debug_assert!(index < Self::CAPACITY);
-        self.data_mut().add(index)
+        unsafe { self.data_mut().add(index) }
     }
 
     #[inline]
     unsafe fn read_at(&self, index: usize) -> A {
-        ptr::read(self.ptr_at(index))
+        unsafe { ptr::read(self.ptr_at(index)) }
     }
 
     #[inline]
     unsafe fn write_at(&mut self, index: usize, value: A) {
-        ptr::write(self.ptr_at_mut(index), value);
+        unsafe { ptr::write(self.ptr_at_mut(index), value) };
     }
 
     /// Get the length of the array.
@@ -409,7 +413,7 @@ impl<A, T> InlineArray<A, T> {
 
     #[inline]
     unsafe fn drop_contents(&mut self) {
-        ptr::drop_in_place::<[A]>(&mut **self) // uses DerefMut
+        unsafe { ptr::drop_in_place::<[A]>(&mut **self) } // uses DerefMut
     }
 
     /// Discard the contents of the array.

--- a/src/sparse_chunk/iter.rs
+++ b/src/sparse_chunk/iter.rs
@@ -12,13 +12,13 @@ where
 }
 
 // Implement Clone instead of deriving, because we want to be Clone even if A isn't.
-impl<'a, A, const N: usize> Clone for Iter<'a, A, N>
+impl<A, const N: usize> Clone for Iter<'_, A, N>
 where
     BitsImpl<N>: Bits,
 {
     fn clone(&self) -> Self {
         Iter {
-            bitmap: self.bitmap.clone(),
+            bitmap: self.bitmap,
             chunk: self.chunk,
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,7 +11,7 @@ impl<'a> DropTest<'a> {
     }
 }
 
-impl<'a> Drop for DropTest<'a> {
+impl Drop for DropTest<'_> {
     fn drop(&mut self) {
         self.counter.fetch_sub(1, Ordering::Relaxed);
     }


### PR DESCRIPTION
Recent-ish rust has added lints for elidable lifetimes and unsafe in unsafe blocks.